### PR TITLE
Update ipsec_tunnels.xml

### DIFF
--- a/Netskope/Generic/ipsec_tunnels.xml
+++ b/Netskope/Generic/ipsec_tunnels.xml
@@ -511,8 +511,11 @@
   </command>
   <command name="CREATE">
     <operation><![CDATA[{literal}{{/literal}
-"enable": {$params.enable|default:'false'},
-
+{if $params.enable == true}
+ "enable": true,
+ {else}
+ "enable": false,
+ {/if}
 "pops": [
   {foreach $params.pops as $pop}
     "{$ipsec_pops.{$pop.pop_name}.object_id|default:''}"{if !$pop@last}, {/if}


### PR DESCRIPTION
Revert condition 
Needs to be explicit  sending true or false. 
without that 1 or 0 will be send as value to netskope  and will throw errors 